### PR TITLE
Feature subjoin without namelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.2] - 2020-05-01
+- (General) Added instructions for contributing to the PepSIRF software.
+
 ## [1.2.1] - 2020-04-06
 - (Demux) Fixed a bug that allowed reads who had a forward index match but no reverse index match be output with a score of zero.
 - (Demux) Fixed a bug causing a difference in scores between aggregate and translation-based non-aggregate scores.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added option to subjoin where exclusion of a name list outputs all columns of a given matrix file.
 - Added error checking and reporting to demux sample list parser and fasta parser.
 - Fixed bug that prevented the 'pepsirf_test' executable from building.
 

--- a/src/modules/subjoin/module_subjoin.cpp
+++ b/src/modules/subjoin/module_subjoin.cpp
@@ -77,7 +77,7 @@ void module_subjoin::run( options *opts )
                 {
                     std::cout << "WARNING: No name list has been given. All scores will be output." << std::endl;
                     // add all sample names to score_name_pair.second
-                    for( auto& s_name : my_data.scores.get_col_labels() )
+                    for( const auto& s_name : my_data.scores.get_col_labels() )
                     {
                         score_name_pair.second.append( s_name.first + "\n" );
                     }

--- a/test/pepsirf_test.cpp
+++ b/test/pepsirf_test.cpp
@@ -2380,13 +2380,11 @@ TEST_CASE( "Determining whether a file is gzipped.", "[pepsirf_io]" )
 
 TEST_CASE( "Subjoin name list filter is optional", "[module_subjoin]" )
 {
-    module_subjoin *mod = new module_subjoin();
-    options_subjoin *opts = new options_subjoin();
-    opts->use_sample_names = true;
-    opts->out_matrix_fname = "../test/test_subjoin_output.txt";
-    opts->matrix_name_pairs.emplace_back( std::make_pair( "../test/test_score_matrix.tsv", "" ) );
-    mod->run( opts );
-    delete( mod );
-    delete( opts );
+    module_subjoin mod = module_subjoin();
+    options_subjoin opts = options_subjoin();
+    opts.use_sample_names = true;
+    opts.out_matrix_fname = "../test/test_subjoin_output.txt";
+    opts.matrix_name_pairs.emplace_back( std::make_pair( "../test/test_score_matrix.tsv", "" ) );
+    mod.run( &opts );
 }
 

--- a/test/pepsirf_test.cpp
+++ b/test/pepsirf_test.cpp
@@ -2383,7 +2383,7 @@ TEST_CASE( "Subjoin name list filter is optional", "[module_subjoin]" )
     module_subjoin *mod = new module_subjoin();
     options_subjoin *opts = new options_subjoin();
     opts->use_sample_names = true;
-    opts->out_matrix_fname = "test_subjoin_output.txt";
+    opts->out_matrix_fname = "../test/test_subjoin_output.txt";
     opts->matrix_name_pairs.emplace_back( std::make_pair( "../test/test_score_matrix.tsv", "" ) );
     mod->run( opts );
     delete( mod );

--- a/test/pepsirf_test.cpp
+++ b/test/pepsirf_test.cpp
@@ -27,6 +27,7 @@
 #include "fastq_parser.h"
 #include "module_demux.h"
 #include "module_deconv.h"
+#include "module_subjoin.h"
 #include "samplelist_parser.h"
 #include "sample.h"
 #include "fastq_score.h"
@@ -2376,3 +2377,16 @@ TEST_CASE( "Determining whether a file is gzipped.", "[pepsirf_io]" )
     std::ifstream false_expected{ "../test/test.fasta" };
     REQUIRE( !pepsirf_io::is_gzipped( false_expected ) );
 }
+
+TEST_CASE( "Subjoin name list filter is optional", "[module_subjoin]" )
+{
+    module_subjoin *mod = new module_subjoin();
+    options_subjoin *opts = new options_subjoin();
+    opts->use_sample_names = true;
+    opts->out_matrix_fname = "test_subjoin_output.txt";
+    opts->matrix_name_pairs.emplace_back( std::make_pair( "../test/test_score_matrix.tsv", "" ) );
+    mod->run( opts );
+    delete( mod );
+    delete( opts );
+}
+

--- a/test/test_score_matrix.tsv
+++ b/test/test_score_matrix.tsv
@@ -1,3 +1,3 @@
     sample1 sample2 sample3
-pep1    1   2   3   4
-pep2    4   5   6   7
+pep1    1   2   3
+pep2    4   5   6

--- a/test/test_score_matrix.tsv
+++ b/test/test_score_matrix.tsv
@@ -1,0 +1,3 @@
+    sample1 sample2 sample3
+pep1    1   2   3   4
+pep2    4   5   6   7


### PR DESCRIPTION
Name list no longer required. When not provided, a warning is given, and all columns from matrix file will be output.