### PR TITLE
Changed output_suffix flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fixed bug where p_enrich -s arg referred to both the output suffix and the sample.
 - Fixed bug causing the max of the specified norm/score to be used in s_enrich
 - Added option to subjoin where exclusion of a name list outputs all columns of a given matrix file.
 - Added error checking and reporting to demux sample list parser and fasta parser.

--- a/src/modules/p_enrich/options_parser_p_enrich.cpp
+++ b/src/modules/p_enrich/options_parser_p_enrich.cpp
@@ -89,7 +89,7 @@ bool options_parser_p_enrich::parse( int argc, char ***argv, options *opts )
           "The sum of each probe's raw count in each sample must be at least either of these "
           "values in order for the sample to be considered.\n"
         )
-        ( "outfile_suffix,a",
+        ( "outfile_suffix,x",
           po::value( &opts_p_enrich->out_suffix )
           ->default_value( "" ),
           "Suffix to add to the names of the samples "

--- a/src/modules/p_enrich/options_parser_p_enrich.cpp
+++ b/src/modules/p_enrich/options_parser_p_enrich.cpp
@@ -89,13 +89,13 @@ bool options_parser_p_enrich::parse( int argc, char ***argv, options *opts )
           "The sum of each probe's raw count in each sample must be at least either of these "
           "values in order for the sample to be considered.\n"
         )
-        ( "outfile_suffix,s",
+        ( "outfile_suffix,a",
           po::value( &opts_p_enrich->out_suffix )
           ->default_value( "" ),
           "Suffix to add to the names of the samples "
           "written to output. For example, '_enriched.txt' can be used. "
           "By default, no suffix is used.\n"
-        ) 
+        )
         ( "join_on,j",
           po::value( &opts_p_enrich->out_fname_join )
           ->default_value( "~" ),
@@ -114,8 +114,8 @@ bool options_parser_p_enrich::parse( int argc, char ***argv, options *opts )
 
     po::store( po::command_line_parser( argc, *argv ).options( desc ).run(), vm);
 
-    if( vm.count( "help" ) 
-        || argc == 2 
+    if( vm.count( "help" )
+        || argc == 2
         )
         {
             std::cout << desc << std::endl;


### PR DESCRIPTION
Changed output_suffix flag to -a (referring to affix) instead of -s to distinguish from sample -s.