### PR TITLE
Feature info increase significant digits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Altered the info module output for sum of column scores to fixed-point notation.
 - Fixed bug causing the max of the specified norm/score to be used in s_enrich
 - Added option to subjoin where exclusion of a name list outputs all columns of a given matrix file.
 - Added error checking and reporting to demux sample list parser and fasta parser.

--- a/src/modules/info/module_info.cpp
+++ b/src/modules/info/module_info.cpp
@@ -58,7 +58,7 @@ void module_info::run( options *opts )
 
                     peptide_names << sample_n.first
                                   << "\t"
-                                  << sum
+                                  << std::fixed << std::setprecision( 2 ) << sum
                                   << "\n";
                 }
 


### PR DESCRIPTION
To prevent rounding of larger sums, the notation was changed to fixed-point notation. Values now appear as a float value with the left side of decimal point allowing an non rounded integer and the right side of the decimal point fixed to two digits.