### PR TITLE
Bug subjoin file input distinction

### DIFF
--- a/include/modules/subjoin/options_subjoin.h
+++ b/include/modules/subjoin/options_subjoin.h
@@ -25,29 +25,29 @@ namespace evaluation_strategy
 };
 
 /**
- * Options for the subjoin module of the 
+ * Options for the subjoin module of the
  * PepSIRF package.
  **/
 class options_subjoin : public options
 {
  public:
 
-    options_subjoin(); 
+    options_subjoin();
     /**
-     * Returns a string of the arguments provided 
+     * Returns a string of the arguments provided
      * to the module.
      **/
     std::string get_arguments();
 
-    std::vector<std::pair<std::string,std::string>> matrix_name_pairs;
-
+    std::vector<std::pair<std::string,std::string>> multi_matrix_name_pairs;
+    std::vector<std::pair<std::string,std::string>> input_matrix_name_pairs;
     /**
      * The name of the file to write output to.
      **/
     std::string out_matrix_fname;
 
     /**
-     * Boolean option to determine whether 
+     * Boolean option to determine whether
      * sample names or peptide names should be
      * used.
      **/

--- a/src/modules/subjoin/options_subjoin.cpp
+++ b/src/modules/subjoin/options_subjoin.cpp
@@ -78,7 +78,7 @@ std::string options_subjoin::get_arguments()
                    input_matrix_name_pairs.end(),
                    [&]( const std::pair<std::string,std::string>& str )
                    {
-                       str_stream << "--filter_scores        "
+                       str_stream << "--input        "
                                   << str.first << "," << str.second
                                   << "\n ";
                    }

--- a/src/modules/subjoin/options_subjoin.cpp
+++ b/src/modules/subjoin/options_subjoin.cpp
@@ -20,7 +20,7 @@ namespace std
         }
     };
 
-}; // namespace std 
+}; // namespace std
 
 
 
@@ -55,7 +55,7 @@ namespace evaluation_strategy
     {
         return string_drs_map.find( strategy )->second;
     }
-    
+
 };
 
 options_subjoin::options_subjoin() = default;
@@ -64,8 +64,18 @@ std::string options_subjoin::get_arguments()
 {
     std::ostringstream str_stream;
 
-    std::for_each( matrix_name_pairs.begin(),
-                   matrix_name_pairs.end(),
+    std::for_each( multi_matrix_name_pairs.begin(),
+                   multi_matrix_name_pairs.end(),
+                   [&]( const std::pair<std::string,std::string>& str )
+                   {
+                       str_stream << "--multi_file        "
+                                  << str.first << "," << str.second
+                                  << "\n ";
+                   }
+                 );
+
+    std::for_each( input_matrix_name_pairs.begin(),
+                   input_matrix_name_pairs.end(),
                    [&]( const std::pair<std::string,std::string>& str )
                    {
                        str_stream << "--filter_scores        "
@@ -77,7 +87,7 @@ std::string options_subjoin::get_arguments()
     str_stream << "--duplicate_evaluation " <<
         evaluation_strategy::string_drs_map[ duplicate_resolution_strategy ]
                << "\n ";
-    str_stream << "--output               " << out_matrix_fname << "\n " << 
+    str_stream << "--output               " << out_matrix_fname << "\n " <<
                   "\n";
 
     return str_stream.str();


### PR DESCRIPTION
Changes:
- Input argument for what was -f is has now become two separate flags, -m and -i. -m takes a filename containing filename pairs and -i takes a single filename pair, where the pairs in both cases are a matrix and name list. Option to exclude a name list and opt for all matrix samples to be used is still available for both flags.
- -f, filter_scores flag is removed.
- The program previously read the title "sequence names" in matrix file when no sample name list was given and warned of its exclusion from the computation. This has been updated to not give a warning for this.