### PR TITLE
demux-ISS96, handling missing names in index file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Demux module now includes a warning when index/barcode names from the samplelist are not included in the fasta file provided by (--index).
 
 ## [1.3.5] - 2021-03-02
 - Fixed penrich bug with threshold verification for enrichment candidates and raw score pairs.

--- a/include/modules/demux/samplelist_parser.h
+++ b/include/modules/demux/samplelist_parser.h
@@ -22,6 +22,15 @@ class samplelist_parser
      * @returns vector of samples, one per line in the input file.
      **/
     std::vector<sample> parse( const options_demux *d_opts );
+
+    /**
+     * Verifies the sample IDs in the samplelist columns used are found in the index id set. Prints missing IDs as warning.
+     * @param index_seq_ids the unordered set that is compared against by the sample ids to verify ids used exist.
+     * @param sample_ids the unordered set that is checked to verify all ids used in the samplelist are existent in the index/barcode list.
+     * 
+     * @returns void
+     **/
+    void check_samples( std::unordered_set<std::string>& index_seq_ids, std::unordered_set<std::string>&  sample_ids );
 };
 
 #endif // SAMPLELIST_PARSER_HH_INCLUDED

--- a/src/modules/demux/samplelist_parser.cpp
+++ b/src/modules/demux/samplelist_parser.cpp
@@ -5,11 +5,13 @@
 // Pass not just filename, but also the string array of headers
 std::vector<sample> samplelist_parser::parse( const options_demux *d_opts )
 { 
-    std::ifstream in_stream( d_opts->samplelist_fname );
+    std::ifstream samplelist_stream( d_opts->samplelist_fname );
     std::size_t line_no = 0;
     std::size_t samplename_idx, id1_col, id2_col;
     std::string line, header_row;
     std::vector<std::string> split_line;
+    std::unordered_set<std::string> sample_id_set;
+    std::unordered_set<std::string> index_id_set;
     std::string name, id1;
     std::string id2 = "";
     int sample_id = 0;
@@ -18,19 +20,19 @@ std::vector<sample> samplelist_parser::parse( const options_demux *d_opts )
     bool id2_found = false;
     std::vector<sample> vec;
 
-    if( !in_stream.is_open() )
+    if( !samplelist_stream.is_open() )
         {
             throw std::runtime_error( "File could not be opened. Verify sample list file exists." );
         }
 
-    std::getline( in_stream, header_row );
+    std::getline( samplelist_stream, header_row );
     boost::trim_right( header_row );
     boost::split( split_line, header_row, boost::is_any_of( "\t" ) );
 
     for( std::size_t curr_col = 0; curr_col < split_line.size(); ++curr_col )
         {
         
-            if( split_line.at( curr_col ) == d_opts->samplename  )
+            if( split_line.at( curr_col ) == d_opts->samplename )
                 {
                     sname_found = true;
                     samplename_idx = curr_col;
@@ -64,7 +66,7 @@ std::vector<sample> samplelist_parser::parse( const options_demux *d_opts )
                          "further information.\n";
         }
     
-    while( std::getline( in_stream, line ) )
+    while( std::getline( samplelist_stream, line ) )
         {
             boost::trim_right( line );
             boost::split( split_line, line, boost::is_any_of( "\t" ) );
@@ -74,12 +76,15 @@ std::vector<sample> samplelist_parser::parse( const options_demux *d_opts )
                 {
                     name = split_line[ samplename_idx ];
                     id1 = split_line[ id1_col ];
+                    sample_id_set.emplace( id1 );
                 }
             else
                 {
                     name = split_line[ samplename_idx ];
                     id1 = split_line[ id1_col ];
                     id2 = split_line[ id2_col ];
+                    sample_id_set.emplace( id1 );
+                    sample_id_set.emplace( id2 );
                 }
             
             // store the series of sample headers into the sample obj.
@@ -87,10 +92,48 @@ std::vector<sample> samplelist_parser::parse( const options_demux *d_opts )
             vec.push_back( samp );
             ++sample_id;
         }
-    if( in_stream.bad() )
+    if( samplelist_stream.bad() )
         {
             throw std::runtime_error( "Encountered error while reading file. Verify sample list file is in .tsv format." );
         }
+    std::ifstream index_stream( d_opts->index_fname );
+    if( !index_stream.is_open() )
+        {
+            throw std::runtime_error( "File could not be opened. Verify fasta file exists." );
+        }
+    while( std::getline( index_stream, line ) )
+        {
+            boost::trim_right( line );
+            if( line.length() > 0 )
+                {
+                    if( line[0] == '>' )
+                        {
+                            index_id_set.emplace( line.substr(1) );
+                        }
+                }
+        }
+    check_samples( index_id_set, sample_id_set );
 
     return vec;
 }
+
+void samplelist_parser::check_samples( std::unordered_set<std::string>& index_seq_ids, std::unordered_set<std::string>& sample_ids )
+    {
+        std::vector<std::string> missing_ids;
+        for( auto& sample_id : sample_ids )
+            {
+                if( index_seq_ids.find( sample_id ) == index_seq_ids.end() )
+                    {
+                        missing_ids.emplace_back( sample_id );
+                    }
+            }
+        if( !missing_ids.empty() )
+            {
+                std::cout << "WARNING: The following index/barcode names from '--samplelist' are not present in the '--index' file:\n";
+                for( auto& id : missing_ids )
+                    {
+                        std::cout << id << "\n";
+                    }
+            }
+
+    }


### PR DESCRIPTION
Added samplelist checking function to verify matching index names between the samplelist and fasta index file.

If the --index option file does not contain names that are present in the --samplelist option file, then a warning is output to the terminal stating missing names are included in the samplelist file and lists the missing names. This issue closes with v1.3.6.
Closes #96 