### PR TITLE
zscore-ISS97, zscore error message occurs when providing incorrect file to --bins

### DIFF
--- a/src/modules/zscore/options_parser_zscore.cpp
+++ b/src/modules/zscore/options_parser_zscore.cpp
@@ -32,7 +32,20 @@ bool options_parser_zscore::parse( int argc, char ***argv, options *opts )
           "format as output by the demux and subjoin modules. "
           "Raw or normalized read counts can be used.\n"
         )
-        ( "bins,b", po::value( &opts_zscore->in_bins_fname )->required(),
+        ( "bins,b", po::value( &opts_zscore->in_bins_fname )->required()
+          ->notifier( [&]( std::string input_filename )->void
+                      {
+
+                        // test whether the second row, second column and every column on contains a double
+                        // if the bin file contains a double, then it is not a bin file and a runtime error should be thrown.
+                        std::ifstream input_f{ input_filename };
+                        if( input_f.fail() )
+                            {
+                              throw std::runtime_error( "Unable to open threshold_file input.\n" );
+                            }
+                        std::string line;
+                      }
+                      ),
           "Name of the file containing bins, one bin per line, as output by the bin module. "
           "Each bin contains a tab-delimited list of peptide names.\n"
         )

--- a/src/modules/zscore/options_parser_zscore.cpp
+++ b/src/modules/zscore/options_parser_zscore.cpp
@@ -1,6 +1,6 @@
 #include "options_parser_zscore.h"
 #include "options_zscore.h"
-
+#include "file_io.h"
 #include <boost/program_options.hpp>
 
 options_parser_zscore::options_parser_zscore() = default;
@@ -41,9 +41,30 @@ bool options_parser_zscore::parse( int argc, char ***argv, options *opts )
                         std::ifstream input_f{ input_filename };
                         if( input_f.fail() )
                             {
-                              throw std::runtime_error( "Unable to open threshold_file input.\n" );
+                              throw std::runtime_error( "Unable to open bins file.\n" );
                             }
                         std::string line;
+                        std::vector<std::string> first_row;
+                        getline( input_f, line );
+                        getline( input_f, line );
+                        boost::split( first_row, line, boost::is_any_of( "\t" ) );
+                        bool is_double = true;
+                        for( const auto& col : first_row )
+                          {
+                            is_double = true;
+                            try
+                            {
+                              std::stod(col);
+                            }
+                            catch(...)
+                            {
+                              is_double = false;
+                            }
+                            if( is_double || col == "nan" || col == "inf" )
+                              {
+                                throw std::runtime_error( "Bins file '" + input_filename + "' provided contains double values. Verify the bins file is valid.\n");
+                              }
+                          }
                       }
                       ),
           "Name of the file containing bins, one bin per line, as output by the bin module. "

--- a/src/modules/zscore/options_parser_zscore.cpp
+++ b/src/modules/zscore/options_parser_zscore.cpp
@@ -62,7 +62,9 @@ bool options_parser_zscore::parse( int argc, char ***argv, options *opts )
                               }
                             if( is_double )
                               {
-                                throw std::runtime_error( "Bins file '" + input_filename + "' provided contains score values. Verify the bins file is valid.\n");
+                                throw std::runtime_error( "Bins file '" + input_filename +
+                                "' provided contains score values. Verify the bins file is valid.\n" +
+                                "Note: this error could also be triggered IF your peptide names include 'inf' or 'nan' (case insensitive).\n");
                               }
                           }
                       }

--- a/src/modules/zscore/options_parser_zscore.cpp
+++ b/src/modules/zscore/options_parser_zscore.cpp
@@ -53,16 +53,16 @@ bool options_parser_zscore::parse( int argc, char ***argv, options *opts )
                           {
                             is_double = true;
                             try
-                            {
-                              std::stod(col);
-                            }
-                            catch(...)
-                            {
-                              is_double = false;
-                            }
-                            if( is_double || col == "nan" || col == "inf" )
                               {
-                                throw std::runtime_error( "Bins file '" + input_filename + "' provided contains double values. Verify the bins file is valid.\n");
+                                std::stod(col);
+                              }
+                            catch(...)
+                              {
+                                is_double = false;
+                              }
+                            if( is_double )
+                              {
+                                throw std::runtime_error( "Bins file '" + input_filename + "' provided contains score values. Verify the bins file is valid.\n");
                               }
                           }
                       }


### PR DESCRIPTION
The --bins option must take a tsv only containing peptide names. A cryptic error occurred after a score matrix was instead provided. This prompted adding a feature to verify the correct file was provided. To check the file the second line of the file is read. If it contains a number(double, NaN, or infinity), then an error message is thrown and stating the incorrect file has been given for the --bins option. This was chosen as the way to check, because the second line of a score matrix will always contain numerical values or complex noncalculable values (inf/NaN). The only concern is if a name in an appropriate bins file contains 'nan' or 'inf', it can still be read as a numerical value and cause an error. A note on this is provided in the error message to inform a user in the case they do happen to have names containing this. This will be implemented in release v1.3.6.
Closes #97 