### PR TITLE
subjoin-ISS99, subjoin output column/row names mixed/disordered

### DIFF
--- a/include/modules/core/matrix.h
+++ b/include/modules/core/matrix.h
@@ -868,6 +868,29 @@ class labeled_matrix : public matrix<ValType>
                          this->row_labels
                        );
         }
+    /**
+     * Update the row labels for this matrix.
+     * @param labels A vector containing the replacement labels.
+     * @post The vector labels must be in the same order as the original labels
+     **/
+    void update_row_labels( const std::vector<std::string> labels )
+        {
+            update_labels( labels,
+                           this->row_labels );
+        }
+
+    /**
+     * Update the col labels for this matrix.
+     * @param labels A vector containing the replacement labels.
+     * @post The vector labels must be in the same order as the original labels.
+     *       If these are not in the same order, then the labels may be
+     *       incorrectly assigned.
+     **/
+    void update_col_labels( const std::vector<std::string> labels )
+        {
+            update_labels( labels,
+                           this->col_labels );
+        }
 
     /**
      * Get the row labels of the matrix, store them in
@@ -1174,6 +1197,25 @@ class labeled_matrix : public matrix<ValType>
                     )
         {
             std::uint32_t idx = 0;
+            label_dest.reserve( std::distance( labels.begin(), labels.end() ) );
+
+            for( const auto& iter_loc : labels )
+                {
+                    label_dest.emplace( iter_loc, idx++ );
+                }
+        }
+    /**
+     * Clears the locally-stored labels for the matrix and emplaces each label from labels.
+     * Each label is stored in label_dest with the value corresponding to the labels index.
+     * @param labels An ordered list of labels to be stored in matrix.
+     * @param label_dest The place to store the label/index mappings.
+     * @post labels is set as vector because an ordered list is necessary to associate index to label.
+     **/
+    void update_labels( const std::vector<std::string> &labels,
+                        std::unordered_map<LabelType, std::uint32_t>& label_dest )
+        {
+            std::uint32_t idx = 0;
+            label_dest.clear();
             label_dest.reserve( std::distance( labels.begin(), labels.end() ) );
 
             for( const auto& iter_loc : labels )

--- a/include/modules/subjoin/module_subjoin.h
+++ b/include/modules/subjoin/module_subjoin.h
@@ -16,7 +16,7 @@ class module_subjoin : public module
  public:
     module_subjoin();
 
-    using name_replacement_list = std::vector<std::pair<std::string,std::string>>;
+    using name_replacement_list = std::unordered_map<std::string,std::string>;
 
     /**
      * Run the subjoin module.
@@ -26,14 +26,13 @@ class module_subjoin : public module
     /**
      * Parse a list of names from the input stream.
      * There should be one name per line in the stream.
-     * @param dest The location to store names, 
-     *        this method will store items found in file at 
-     *        the end of the vector.
+     * @param dest The location to store names to be used in the matrix. 
+     *        This method will store names from the first column of namelist.
      * @param file A stream to read names from.
-     * @returns a list of the names that should be replaced in 
+     * @returns a list name pairs used to replace existing names in 
      *          the output. Each entry in the list will be 
      *          a pair of strings, with the first being the original name
-     *          and the second the new value.
+     *          and the second the new/replacement name.
      **/
     name_replacement_list
         parse_namelist( std::vector<std::string>& dest,

--- a/src/modules/subjoin/module_subjoin.cpp
+++ b/src/modules/subjoin/module_subjoin.cpp
@@ -28,9 +28,11 @@ module_subjoin::parse_namelist( std::vector<std::string>& dest,
                     boost::split( split_line, line, boost::is_any_of( "\t" ) );
 
                     // replace the old name with the new
-                    if( split_line.size() == 2 && split_line[ 1 ].length() > 0 )
+                    if( split_line.size() == 2 && split_line[ 1 ].length() > 0 
+                    
+                    )
                         {
-                            dest.emplace_back( split_line[ 1 ] );
+                            dest.emplace_back( split_line[ 0 ] );
                             ret_val.emplace_back( std::make_pair( split_line[ 0 ],
                                                                   split_line[ 1 ]
                                                                 )
@@ -80,7 +82,6 @@ void module_subjoin::run( options *opts )
 
     time.start();
 
-    // for all of the ( score_matrix, names_to_filter ) pairs:
     #pragma omp parallel for num_threads( 2 ) private( idx ) schedule( dynamic ) \
             shared( matrix_name_pairs, parsed_score_data )
     for( idx = 0; idx < matrix_name_pairs.size(); ++idx )
@@ -95,108 +96,95 @@ void module_subjoin::run( options *opts )
             peptide_scoring::parse_peptide_scores( my_data,
                                                 matrix_name_list
                                                 );
-                if( use_peptide_names )
-                    {
-                        my_data.scores = my_data.scores.transpose();
-                    }
+            if( use_peptide_names )
+                {
+                    my_data.scores = my_data.scores.transpose();
+                }
 
-                // parse the peptide scores
-                std::vector<std::string> peptide_name_list;
-                name_replacement_list replacement_names;
-                if( score_name_pair.second.empty() )
-                    {
-                        std::string line;
-                        std::ifstream matrix_names( matrix_name_list,
-                                                     std::ios_base::in );
-                        std::getline( matrix_names, line );
+            // parse the peptide scores
+            std::vector<std::string> peptide_name_list;
+            name_replacement_list replacement_names;
+            if( score_name_pair.second.empty() )
+                {
+                    std::string line;
+                    std::ifstream matrix_names( matrix_name_list,
+                                                    std::ios_base::in );
+                    std::getline( matrix_names, line );
 
-                        boost::split( peptide_name_list, line, boost::is_any_of( "\t" ) );
+                    boost::split( peptide_name_list, line, boost::is_any_of( "\t" ) );
 
-                    }
-                else
-                    {
-                        std::ifstream names_list( score_name_pair.second,
-                                                std::ios_base::in
-                                                );
-                        replacement_names = parse_namelist( peptide_name_list, names_list );
-                    }
-                auto replace_begin = use_peptide_names ? my_data.pep_names.begin()
+                }
+            else
+                {
+                    std::ifstream names_list( score_name_pair.second,
+                                            std::ios_base::in
+                                            );
+                    replacement_names = parse_namelist( peptide_name_list, names_list );
+                }
+            auto replace_begin = use_peptide_names ? my_data.pep_names.begin()
                                       : my_data.sample_names.begin();
 
-                auto replace_end = use_peptide_names ? my_data.sample_names.end()
-                                      : my_data.sample_names.end();
+            auto replace_end = use_peptide_names ? my_data.sample_names.end()
+                                    : my_data.sample_names.end();
 
-                for( const auto& name_repl_pair : replacement_names )
-                    {
-                        if( my_data.scores.get_row_labels().find( name_repl_pair.first )
-                            != my_data.scores.get_row_labels().end()
-                          )
-                            {
-                                my_data.scores.set_row_label( name_repl_pair.first,
-                                                              name_repl_pair.second
-                                                              );
-                                std::replace( replace_begin,
-                                              replace_end,
-                                              name_repl_pair.first,
-                                              name_repl_pair.second
-                                              );
-                            }
-                        else
-                            {
-                                    std::cout << "WARNING: The sample "
-                                          << name_repl_pair.first
-                                          << " was not found in "
-                                          << "the input matrix, "
-                                          << "and will not be included in the output.\n";
-                            }
-                    }
-
-                // filter the data, assign to the scores and peptide name list
-                std::unordered_set<std::string> names;
-
-                if( use_peptide_names )
-                    {
-                        names.insert( my_data.pep_names.begin(),
-                                      my_data.pep_names.end()
-                                      );
-
-                    }
-                else
-                    {
-                        names.insert( my_data.sample_names.begin(),
-                                      my_data.sample_names.end()
+            std::unordered_set<std::string> names;
+            std::size_t curr_name_idx;
+            if( use_peptide_names )
+                {
+                    names.insert( my_data.pep_names.begin(),
+                                    my_data.pep_names.end()
                                     );
-                    }
-
-                std::vector<std::string> filter_list;
-
-                std::for_each( peptide_name_list.begin(),
-                               peptide_name_list.end(),
-                               [&]( const std::string& name )
-                               -> void { bool res = names.find( name )
-                                       != names.end();
-                                   if( !res )
-                                       {
-                                           if( boost::to_lower_copy( name ) != "sequence name" )
-                                                {
-                                                    std::cout << "WARNING: The sample "
-                                                            << name
-                                                            << " was not found in "
-                                                            << "the input matrix, "
-                                                            << "and will not be included in the output.\n";
-                                                }
-                                       }
-                                   else
-                                       {
-                                           filter_list.emplace_back( name );
-                                       }
-                               }
-                             );
-
-
-
-                my_data.scores = my_data.scores.filter_rows( filter_list );
-                my_data.pep_names = filter_list;
+                }
+            else
+                {
+                    names.insert( my_data.sample_names.begin(),
+                                    my_data.sample_names.end()
+                                );
+                }
+            // verify given filter names exist
+            for( curr_name_idx = 0; curr_name_idx < peptide_name_list.size(); curr_name_idx++ )
+                {
+                    if( names.find( peptide_name_list[ curr_name_idx ] )  == names.end()
+                        && boost::to_lower_copy( peptide_name_list[ curr_name_idx ] ) != "sequence name" )
+                        {
+                            std::cout << "WARNING: The sample "
+                                    << peptide_name_list[ curr_name_idx ]
+                                    << " was not found in "
+                                    << "the input matrix, "
+                                    << "and will not be included in the output.\n";
+                            peptide_name_list.erase( peptide_name_list.begin() + curr_name_idx );
+                        }
+                }
+            // filter out unused rows
+            my_data.scores = my_data.scores.filter_rows( peptide_name_list );
+            my_data.pep_names = peptide_name_list;
+            std::vector<std::string> filter_list;
+            std::size_t curr_replacement_idx = 0;
+            for( curr_name_idx = 0; curr_name_idx < peptide_name_list.size(); curr_name_idx++ )
+                {
+                    if( names.find( peptide_name_list[ curr_name_idx ] ) != names.end() )
+                        {
+                            // if the name is found and has a replacement for output, then use the replacement name as the filter.
+                            if( curr_replacement_idx < replacement_names.size()
+                                && replacement_names[ curr_replacement_idx ].first == peptide_name_list[ curr_name_idx ] )
+                                {
+                                    filter_list.emplace_back( replacement_names[ curr_replacement_idx ].second );
+                                    my_data.scores.set_row_label( replacement_names[ curr_replacement_idx ].first,
+                                                            replacement_names[ curr_replacement_idx ].second
+                                                        );
+                                    std::replace( replace_begin,
+                                                replace_end,
+                                                replacement_names[ curr_replacement_idx ].first,
+                                                replacement_names[ curr_replacement_idx ].second
+                                                );
+                                    curr_replacement_idx++;
+                                }
+                            else
+                                {
+                                    filter_list.emplace_back( peptide_name_list[ curr_name_idx ] );
+                                }
+                        }
+                }
         }
 
     std::ofstream output( s_opts->out_matrix_fname, std::ios_base::out );


### PR DESCRIPTION
In subjoin, a namelist can be provided alongside a score matrix. This namelist acts as a filter, where the file can contain up to two columns of names. The first column is a list of the names that can be found in the matrix and are desired to be included in the process of the run. The second column can contain name updates for the first column. The issue in subjoin was with these name updates. If a name update was a name already used in the matrix, even if it was being updated itself, then the names in the output could be switched around incorrectly. This had to do with the way the data was stored - the names are not stored in a sequential structure and are accessed stochastically. Subjoin should now properly update names when necessary and in the case of an attempted duplicate name in output an error is thrown which notifies the user a name is used more than once in the column/row names. This issue also brought the creation of an additional method for the matrix.h file. update_labels is now available. The row/column labels in the matrix can now be cleared and replaced with an updated vector of values. The index of each name value staying consistent to the original names is crucial to maintaining the order of names. This update and fix will be implemented in release 1.3.6. Closes #99 