### PR TITLE
demux-ISS100, diagnostics incorrectly calculated for both optional output file and terminal output

### DIFF
--- a/src/modules/demux/module_demux.cpp
+++ b/src/modules/demux/module_demux.cpp
@@ -199,7 +199,7 @@ void module_demux::run( options *opts )
                                         {
                                             for( auto& sample : diagnostic_map )
                                                 {
-                                                    if( idx1_match->first.name.compare( sample.first.first ) == 0 )
+                                                    if( idx1_match->first.name == sample.first.first )
                                                         {
                                                             sample.second.second.at( 0 ) += 1;
                                                         }
@@ -218,14 +218,10 @@ void module_demux::run( options *opts )
                                                 ++idx2_match_total;
                                             for( auto& sample : diagnostic_map )
                                                 {
-                                                    if( idx2_match->first.name.compare( sample.first.second ) == 0
-                                                        && idx1_match->first.name.compare( sample.first.first ) == 0 )
+                                                    if( idx2_match->first.name == sample.first.second
+                                                        && idx1_match->first.name == sample.first.first )
                                                         {
-                                                            if( !d_opts->diagnostic_fname.empty() )
-                                                                {
-                                                                    sample.second.second.at( 1 ) += 1;
-                                                                }
-                                                            
+                                                            sample.second.second.at( 1 ) += 1;                                                            
                                                         }
                                                 }
                                             return true;

--- a/src/modules/zscore/options_parser_zscore.cpp
+++ b/src/modules/zscore/options_parser_zscore.cpp
@@ -1,6 +1,5 @@
 #include "options_parser_zscore.h"
 #include "options_zscore.h"
-#include "file_io.h"
 #include <boost/program_options.hpp>
 
 options_parser_zscore::options_parser_zscore() = default;
@@ -32,41 +31,7 @@ bool options_parser_zscore::parse( int argc, char ***argv, options *opts )
           "format as output by the demux and subjoin modules. "
           "Raw or normalized read counts can be used.\n"
         )
-        ( "bins,b", po::value( &opts_zscore->in_bins_fname )->required()
-          ->notifier( [&]( std::string input_filename )->void
-                      {
-
-                        // test whether the second row, second column and every column on contains a double
-                        // if the bin file contains a double, then it is not a bin file and a runtime error should be thrown.
-                        std::ifstream input_f{ input_filename };
-                        if( input_f.fail() )
-                            {
-                              throw std::runtime_error( "Unable to open bins file.\n" );
-                            }
-                        std::string line;
-                        std::vector<std::string> first_row;
-                        getline( input_f, line );
-                        getline( input_f, line );
-                        boost::split( first_row, line, boost::is_any_of( "\t" ) );
-                        bool is_double = true;
-                        for( const auto& col : first_row )
-                          {
-                            is_double = true;
-                            try
-                            {
-                              std::stod(col);
-                            }
-                            catch(...)
-                            {
-                              is_double = false;
-                            }
-                            if( is_double || col == "nan" || col == "inf" )
-                              {
-                                throw std::runtime_error( "Bins file '" + input_filename + "' provided contains double values. Verify the bins file is valid.\n");
-                              }
-                          }
-                      }
-                      ),
+        ( "bins,b", po::value( &opts_zscore->in_bins_fname )->required(),
           "Name of the file containing bins, one bin per line, as output by the bin module. "
           "Each bin contains a tab-delimited list of peptide names.\n"
         )


### PR DESCRIPTION
The output for the diagnostics in the command-line interface should consist of counts for the number of instances a distinct index1 barcode/index name found a match in the reads, the number of counts where a given index1 match occurred followed by a paired index2 match (pair match), and when a pair match in ref-depend mode occurs, if a variable region match occurs the count should increment. The diagnostic file should contain matches specific to the samplename it occurred. When an index/barcode name has a match it should be counted for every sample that includes that index. A pair match should only be valid if the indexes are a pair for a given sample, opposed to being names that are present in the samplesheet, but not paired up. And the count for variable region matches, if applicable, should be recorded for each samplename. Two issues primarily occurred which caused incorrect calculations: barcode/index names that are not included in the samplesheet were being included in the match counts - which grossly inflated the terminal output match counts and impacted the diagnostic file counts, and the pair matches were not sufficiently checked whether they were provided pairs in the samplesheet causing pair matches for index pairs that didn't exist. Using only linked barcode/index names and properly verifying pair matches were the primary changes made. These changes will be implemented in v1.3.6. This closes #100 