### PR TITLE
option for enriched file containing path and names

### DIFF
--- a/extensions/enrichedScatterplots.py
+++ b/extensions/enrichedScatterplots.py
@@ -39,6 +39,10 @@ def main():
     p.add_option('--ptsTrans', type=float, default=0.5, help='Transparency to use for plotted points. [0.5]')
 
     opts, args = p.parse_args()
+    
+    #Check if enriched directory and file were both provided and issue warning
+    if opts.enrFile and opts.enrDir:
+        print("Warning: An enriched directory and an enriched file were provided. File will be used, and directory will be ignored.")
 
     #Create output dir
     if os.path.isdir(opts.outDir):
@@ -83,10 +87,6 @@ def main():
         enrFiles = glob.glob("%s/*%s" % (opts.enrDir, opts.enrExt))
     else:
         print("Warning: No enriched directory or file provided. Must provide one.")
-
-    #Check if enriched directory and file were both provided and issue warning
-    if opts.enrFile and opts.enrDir:
-        print("Warning: An enriched directory and an enriched file were provided. File will be used, and directory will be ignored.")
 
     #Generate plot for each list of enriched peptides
     for eF in enrFiles:

--- a/extensions/enrichedScatterplots.py
+++ b/extensions/enrichedScatterplots.py
@@ -23,6 +23,7 @@ def main():
     p.add_option('-e', '--enrDir',  help='Directory containing lists of enriched peptides. [None, REQ]')
     p.add_option('--enrExt', help='Common file ending for files containing enriched sets of peptides. Once removed, the remaining filename should consist only of sample name(s) [None, REQ]')
     p.add_option('--snDelim', default="~", help='Delimiter used to separate sample names in pEnrich files [~]')
+    p.add_option('-f', '--enrFile', help='Tab delimited file containing data that will be used to generate scatterplots. [None, OPT]')
 
     #Negative contols
     p.add_option('--negMatrix',  help='Optional way to provide a separate data matrix for negative controls. If not provided, negative controls will be assumed to be from the same matrix as the experiemntal data  [None, OPT]')
@@ -65,12 +66,30 @@ def main():
     x = [np.mean([float(negD[sn][pn]) for sn in negNames]) for pn in peptideNames]
     
     # Read in lists of enriched peptides
-    enrFiles = glob.glob("%s/*%s" % (opts.enrDir, opts.enrExt))
+    if opts.enrDir:
+        enrFiles = glob.glob("%s/*%s" % (opts.enrDir, opts.enrExt))
+    elif opts.enrFile:
+        filePath = {}
+        with open(opts.enrFile, 'r') as fin:
+            for line in fin:
+                filelist = line.strip("\n").split("\t")
+                filePath[filelist[0]] = []
+                i = 1
+                while i < len(filelist):
+                    if filelist[i] =='':
+                        i += 1
+                    else:
+                        filePath[filelist[0]].append(filelist[i])
+                        i += 1
+        enrFiles = list(filePath.keys())
 
     #Generate plot for each list of enriched peptides
     for eF in enrFiles:
         enrichedD = io.fileEmptyDict(eF, header=False)
-        sNames = os.path.basename(eF).split(opts.enrExt)[0].split(opts.snDelim)
+        if opts.enrDir:
+            sNames = os.path.basename(eF).split(opts.enrExt)[0].split(opts.snDelim)
+        elif opts.enrFile:
+            sNames = filePath[eF]
         
         #Average values for y-axis
         y = [np.mean([float(dataD[sn][pn]) for sn in sNames]) for pn in peptideNames]


### PR DESCRIPTION
Adding the command-line option (-f, --enrFile) for a tab-delimited file to be provided containing the file paths of the enriched files and the sample names. Command-line option (-e, --enrDir) for a directory containing the enriched files is still maintained, as well as all original functionality.

The user is able to provide both a directory and a file, but the file will be the default, and the user must provide at least one. Warnings have been added for both scenarios.