### PR TITLE
updating plogLog and adding negative_id - issue119/20

### DIFF
--- a/extensions/enrichedScatterplots.py
+++ b/extensions/enrichedScatterplots.py
@@ -67,10 +67,14 @@ def main():
                 negNames.append(name)
         if not negNames:
             print("Warning: No samples found matching the provided negative ID")
-    elif not opts.negControls:
-        negNames = list(negD.keys())
+    elif opts.negControls:
+        negNames = opts.negControls.split(",")
     else:
-       negNames = opts.negControls.split(",")
+        if opts.negMatrix:
+            print("Warning: Using all samples in %s to generate x-axis values" % opts.negMatrix)
+        else:
+            print("Warning: Using all samples in %s to generate x-axis values" % opts.data)
+        negNames = list(negD.keys())
     
     peptideNames = list(negD[negNames[0]].keys())
     
@@ -116,8 +120,8 @@ def main():
         if opts.plotLog:
             x = [np.log10(point+opts.plotLog)for point in x]
             y = [np.log10(point+opts.plotLog)for point in y]
-            ax.set_ylabel(",".join(sNames)+f"log10(value+{opts.plotLog})", fontsize=15)
-            ax.set_xlabel(opts.xLabel+f"log10(value+{opts.plotLog})", fontsize=15)
+            ax.set_ylabel(",".join(sNames)+f" log10(value+{opts.plotLog})", fontsize=15)
+            ax.set_xlabel(opts.xLabel+f" log10(value+{opts.plotLog})", fontsize=15)
         else:
             ax.set_ylabel(",".join(sNames), fontsize=15)
             ax.set_xlabel(opts.xLabel, fontsize=15)  

--- a/extensions/enrichedScatterplots.py
+++ b/extensions/enrichedScatterplots.py
@@ -27,12 +27,13 @@ def main():
     #Negative contols
     p.add_option('--negMatrix',  help='Optional way to provide a separate data matrix for negative controls. If not provided, negative controls will be assumed to be from the same matrix as the experiemntal data  [None, OPT]')
     p.add_option('-c', '--negControls',  help='Comma-delimited names of samples to use as negative controls. If this is not provided, then all of the samples in the negative control matrix will be used [None, REQ]')
+    p.add_option('-i', '--negative_id', help='Optional approach for identifying negative controls. Provide a unique string at the start of all negative control samples. [None, OPT]')
     p.add_option('-x', '--xLabel', default="", help='Label to be used for x-axis. []')
 
     #Output controls
     p.add_option('-o', '--outDir', help='Directory name for output files. Will be created. [None]')
     p.add_option('--plotType', default="png", help='Type of plot to generate. This should be a file extension recognized by matplotlib, e.g., pdf, png, tiff [png]')
-    p.add_option('--plotLog', default=False, action="store_true", help="Use if you want axes to be shown on a log-scale. [False]")
+    p.add_option('--plotLog', type=float, default=False, help="Use if you want axes to be shown on a log-scale. Argument provided should be a float to add to the axes before calcluating the log value [False]")
     p.add_option('--negColor', default="#1b9e77", help='Color to use for Unenriched peptides. [#1b9e77]')
     p.add_option('--posColor', default="#d95f02", help='Color to use for Enenriched peptides. [#d95f02]')
     p.add_option('--ptsSize', type=float, default=10, help='Size to use for plotted points. [10]')
@@ -59,10 +60,17 @@ def main():
     else:
         negD = dataD
     
-    if not opts.negControls:
+    if opts.negative_id:
+        negNames = []
+        for name in negD.keys():
+            if name.startswith(opts.negative_id):
+                negNames.append(name)
+        if not negNames:
+            print("Warning: No samples found matching the provided negative ID")
+    elif not opts.negControls:
         negNames = list(negD.keys())
     else:
-        negNames = opts.negControls.split(",")
+       negNames = opts.negControls.split(",")
     
     peptideNames = list(negD[negNames[0]].keys())
     
@@ -106,12 +114,15 @@ def main():
         fig,ax = plt.subplots(1,1,figsize=(5,5),facecolor='w')            
         
         if opts.plotLog:
-            ax.scatter(np.log10(x), np.log10(y), c=c, alpha=opts.ptsTrans, s=opts.ptsSize)
+            x = [np.log10(point+opts.plotLog)for point in x]
+            y = [np.log10(point+opts.plotLog)for point in y]
+            ax.set_ylabel(",".join(sNames)+f"log10(value+{opts.plotLog})", fontsize=15)
+            ax.set_xlabel(opts.xLabel+f"log10(value+{opts.plotLog})", fontsize=15)
         else:
-            ax.scatter(x, y, c=c, alpha=opts.ptsTrans, s=opts.ptsSize)
-
-        ax.set_ylabel(",".join(sNames), fontsize=15)
-        ax.set_xlabel(opts.xLabel, fontsize=15)
+            ax.set_ylabel(",".join(sNames), fontsize=15)
+            ax.set_xlabel(opts.xLabel, fontsize=15)  
+            
+        ax.scatter(x, y, c=c, alpha=opts.ptsTrans, s=opts.ptsSize)
 
 #        if lim:
 #            ax.set_xlim(lim[0], lim[1])


### PR DESCRIPTION
Updating "--plotLog" command-line option to now be accompanied by a floating-point argument that will be added to the points prior to log normalization. In addition, both axes labels will have "log10(value+plotLogargument)" added to the end of them when "--plotLog" is selected.

Adding "-i"/"--negative_id" as a command-line option to be used in place of the command-line option "-c"/"--negativeControl". It will allow the user to provide a string that is unique to the start of the negative control samples (code will make use of string.startswith() to accomplish this). If no samples were found matching the negative ID, a warning will be issued.