### PR TITLE
add --enrichedScatters option

### DIFF
--- a/extensions/autoPepSIRF.py
+++ b/extensions/autoPepSIRF.py
@@ -267,10 +267,10 @@ def main():
             if args.negNormMat:
                 cmd += (' --negMatrix %s' % args.negNormMat)
                 
-                if args.negative_id:
-                    cmd += (' -i %s' % args.negative_id)
-                elif args.negative_names:
-                    cmd += (' -c %s' % args.negative_names)
+            if args.negative_id:
+                cmd += (' -i %s' % args.negative_id)
+            elif args.negative_names:
+                cmd += (' -c %s' % args.negative_names)
                     
             subprocess.run(cmd, shell=True)
 

--- a/extensions/autoPepSIRF.py
+++ b/extensions/autoPepSIRF.py
@@ -213,9 +213,9 @@ def main():
         print(cmd)
         subprocess.run(cmd, shell=True)
     # Turn off enriched scatterplots generation, as they cannot be run without a list of enriched peptides
-    elif args.enrichedScatterplots:
-        print("Warning: p_enrich module not run and list of enriched peptides not generated. --enrichedScatterplots will be set to False.")
-        args.enrichedScatterplots = False
+    elif args.enrichedScatters:
+        print("Warning: p_enrich module not run and list of enriched peptides not generated. --enrichedScatters will be set to False.")
+        args.enrichedScatters = False
 
     
     if matplotReady:

--- a/extensions/autoPepSIRF.py
+++ b/extensions/autoPepSIRF.py
@@ -213,7 +213,7 @@ def main():
         print(cmd)
         subprocess.run(cmd, shell=True)
     # Turn off enriched scatterplots generation, as they cannot be run without a list of enriched peptides
-    elif args.enrichedScatterplots and not args.thresh and not args.pairs and not base:
+    elif args.enrichedScatterplots:
         print("Warning: p_enrich module not run and list of enriched peptides not generated. --enrichedScatterplots will be set to False.")
         args.enrichedScatterplots = False
 
@@ -269,10 +269,13 @@ def main():
                 
             if args.negative_id:
                 cmd += (' -i %s' % args.negative_id)
-            elif args.negative_names:
+                
+            if args.negative_names:
                 cmd += (' -c %s' % args.negative_names)
                     
             subprocess.run(cmd, shell=True)
+        elif args.enrichedScatters:
+            print("Warning: plots will not be generated because colsum is not set")
 
 
 #----------------------End of main()


### PR DESCRIPTION
Add a new command-line option "--enrichedScatters" to allow automatic generation of scatterplots that compare col-sum normalized read counts between a sample and negative controls.

The flag is accompanied by an argument of how to call enrichedScatterplots.py, so it can be called to generate the plots.

If p_enrich module is not run, a warning will be printed and the flag will be set to false. Otherwise, a enrichedScatterplots, directory, containing the plots, will be placed in the enriched peptides directory.