### PR TITLE
Enrich iss103 - Failure to generate enriched peptides reasoning output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - #114, s_enrich and p_enrich have been merged into a single module 'enrich'. A single and pair of samplenames work with the same behavior as s_ and p_enrich respectively. Additionally, >2 replicates can be analyzed to generate enriched peptides. See help options for an update on the options.
+- #103, enrich (previously two separate modules, s_enrich and p_enrich) module now features an optional flag that outputs in a tsv failed enrichment replicate sets. Any set replicates which failed to generate enriched peptides is listed in this file. Each row contains a column for replicate samplenames and a column containing the reason.
 
 ## [1.3.7] - 2021-06-28
 - #125, norm module incorrectly stored peptide names with the assumption that in diff, diff-ratio, or ratio the control and original matrix are in the same order. The peptide names should not be assumed to be in the same order. This has been updated by changing the type of container used and the method of access.

--- a/include/modules/enrich/module_enrich.h
+++ b/include/modules/enrich/module_enrich.h
@@ -59,9 +59,9 @@ public:
     }
 
     /**
-     * Determine if the threshold for a given pair of values
+     * Determine if the threshold for a given list of values
      * is met.
-     * For a given pair of values to meet a given threshold,
+     * For a given list of values to meet a given threshold,
      * the smallest value must be greater than the smallest threshold
      * and the largest value must be greater than the largest threshold.
      * @param values The values to test
@@ -117,11 +117,12 @@ public:
                                       const std::vector<std::string> sample_names );
 
     /**
-     * Get enrichment candidates for peptides in a sample pair.
-     * @param enrichment_candidates pointer to map of paired score values for
-     *        each peptide where the key is the peptide name
+     * Get enrichment candidates for peptides in a sample list. Each candidate is a pair:
+     * (peptide name, list of scores for specified sample columns)
+     * @param enrichment_candidates pointer to map of score(s) for
+     *        each peptide where the key is the peptide name and the value is a list of >=1 scores.
      * @param matrix_score_data pointer to data containing normalized scores.
-     * @param sample_names the pair of samples to get enrichment candidates for.
+     * @param sample_names the list of samples to get enrichment candidates for.
      * @param returns void
      **/
     void get_enrichment_candidates( std::map<std::string,std::vector<double>> *enrichment_candidates,

--- a/include/modules/enrich/options_enrich.h
+++ b/include/modules/enrich/options_enrich.h
@@ -31,6 +31,8 @@ class options_enrich : public options
 
     std::string out_dirname;
 
+    std::string out_enrichment_failure;
+
     std::string out_fname_join;
 
     std::string out_suffix;

--- a/src/modules/enrich/module_enrich.cpp
+++ b/src/modules/enrich/module_enrich.cpp
@@ -117,17 +117,7 @@ void module_enrich::run( options *opts )
             raw_count_enriched = raw_counts_included
                 ? ( raw_count_enriched && thresholds_met( col_sums, raw_score_params ) )
                 : true;
-            if( raw_counts_included && !raw_count_enriched )
-                {
-                    std::string samplenames = "";
-                    std::for_each( samples_list[sample_idx].begin(), samples_list[sample_idx].end() - 1,
-                        [&]( std::string name )
-                            {
-                                samplenames.append( name + ", " );
-                            });
-                    samplenames.append( *(samples_list[sample_idx].end() - 1) );                  
-                    enrichment_failures.emplace( samplenames, "raw" );
-                }
+
             if( raw_count_enriched )
             {
                 // Get candidates for each input matrix for the current sample
@@ -202,7 +192,18 @@ void module_enrich::run( options *opts )
                     }
             }
 
-            if( enriched_probes.empty() && !e_opts->out_enrichment_failure.empty() )
+            if( raw_counts_included && !raw_count_enriched && !e_opts->out_enrichment_failure.empty() )
+                {
+                    std::string samplenames = "";
+                    std::for_each( samples_list[sample_idx].begin(), samples_list[sample_idx].end() - 1,
+                        [&]( std::string name )
+                            {
+                                samplenames.append( name + ", " );
+                            });
+                    samplenames.append( *(samples_list[sample_idx].end() - 1) );                  
+                    enrichment_failures.emplace( samplenames, "raw" );
+                }
+            else if( enriched_probes.empty() && !e_opts->out_enrichment_failure.empty() )
                 {
                     std::string samplenames = "";
                     std::for_each( samples_list[sample_idx].begin(), samples_list[sample_idx].end() - 1,

--- a/src/modules/enrich/module_enrich.cpp
+++ b/src/modules/enrich/module_enrich.cpp
@@ -23,6 +23,7 @@ void module_enrich::run( options *opts )
     peptide_score_data_sample_major *raw_scores_ptr = nullptr;
     std::vector<double> raw_score_params;
     std::vector<std::pair<peptide_score_data_sample_major,std::vector<double>>> matrix_thresh_pairs;
+    std::unordered_map<std::string,std::string> enrichment_failures;
     matrix_thresh_pairs.resize( e_opts->matrix_thresh_fname_pairs.size() );
     bool shorthand_output_filenames = e_opts->truncate_names;
     std::size_t curr_matrix;
@@ -116,6 +117,17 @@ void module_enrich::run( options *opts )
             raw_count_enriched = raw_counts_included
                 ? ( raw_count_enriched && thresholds_met( col_sums, raw_score_params ) )
                 : true;
+            if( raw_counts_included && !raw_count_enriched )
+                {
+                    std::string samplenames = "";
+                    std::for_each( samples_list[sample_idx].begin(), samples_list[sample_idx].end() - 1,
+                        [&]( std::string name )
+                            {
+                                samplenames.append( name + ", " );
+                            });
+                    samplenames.append( *(samples_list[sample_idx].end() - 1) );                  
+                    enrichment_failures.emplace( samplenames, "raw" );
+                }
             if( raw_count_enriched )
             {
                 // Get candidates for each input matrix for the current sample
@@ -134,10 +146,6 @@ void module_enrich::run( options *opts )
                                                         "not the same.\n"
                                                         );
                             }
-                        // bool first_in = matrix_sample_names.find( samples_list[sample_idx].first )
-                        //             != matrix_sample_names.end();
-                        // bool second_in = matrix_sample_names.find( samples_list[sample_idx].second )
-                        //             != matrix_sample_names.end();
                         std::vector<std::string> sample_diffs;
                         std::set_difference( samples_sample_names.begin(), samples_sample_names.end(),
                                              matrix_sample_names.begin(), matrix_sample_names.end(), sample_diffs.begin() );
@@ -167,7 +175,7 @@ void module_enrich::run( options *opts )
                             }
                         else
                             {
-                                //create a vector of enrichment candidates - each vector of paired scores for a thresholds file provided
+
                                 get_enrichment_candidates( &all_enrichment_candidates[curr_matrix],
                                                         curr_matrix_ptr,
                                                         samples_list[ sample_idx ]
@@ -176,7 +184,6 @@ void module_enrich::run( options *opts )
                             }
                     }
 
-                // verify all candidates of the same peptide name are equal to or over given thresholds
                 for( const auto& candidate : all_enrichment_candidates[0] )
                     {
                         std::string pep_name = candidate.first;
@@ -194,10 +201,19 @@ void module_enrich::run( options *opts )
                             }
                     }
             }
-            // What if for output, if there are more than 3 samplenames,
-            // then do what Jason said about the "S_000~S_001~_S_002_#more_enriched.txt" (if they use the option otherwise let it include all.)
 
-            if( !enriched_probes.empty() )
+            if( enriched_probes.empty() && !e_opts->out_enrichment_failure.empty() )
+                {
+                    std::string samplenames = "";
+                    std::for_each( samples_list[sample_idx].begin(), samples_list[sample_idx].end() - 1,
+                        [&]( std::string name )
+                            {
+                                samplenames.append( name + ", " );
+                            });
+                    samplenames.append( *(samples_list[sample_idx].end() - 1) );                  
+                    enrichment_failures.emplace( samplenames, "peptides" );
+                }
+            else if( !enriched_probes.empty() )
                 {
                     std::string outf_name = e_opts->out_dirname + '/';
                     if( shorthand_output_filenames && samples_list[sample_idx].size() > 3 )
@@ -225,6 +241,27 @@ void module_enrich::run( options *opts )
                                         );
                 }
 
+        }
+
+    if( !e_opts->out_enrichment_failure.empty() && !enrichment_failures.empty() )
+        {
+            std::string outf_name = e_opts->out_dirname + '/' + e_opts->out_enrichment_failure;
+            // write to file
+            std::ofstream out_file{ outf_name, std::ios_base::out };
+            out_file << "Replicates\tReason\n";
+            for( auto& line : enrichment_failures )
+                {
+                    out_file << line.first;
+                    if( line.second == "raw" )
+                        {
+                            out_file << "\tRaw read count threshold.\n";
+                        }
+                    else
+                        {
+                            out_file << "\tNo enriched peptides.\n";
+                        }
+                }
+            out_file.close();
         }
 }
 std::vector<module_enrich::sample_type> module_enrich::parse_samples( std::istream& file )

--- a/src/modules/enrich/options_enrich.cpp
+++ b/src/modules/enrich/options_enrich.cpp
@@ -18,7 +18,8 @@ std::string options_enrich::get_arguments()
                   << "--raw_score_constraint       " << raw_scores_params_str << "\n ";
         }
 
-    stream << "--outfile_suffix             " << out_suffix << "\n "
+    stream << "--enrichment_failure_reason  " << out_enrichment_failure << "\n"
+           << "--outfile_suffix             " << out_suffix << "\n "
            << "--join_on                    " << out_fname_join << "\n "
            << "--output_filename_truncate   "
            << "--output                     " << out_dirname << "\n "

--- a/src/modules/enrich/options_parser_enrich.cpp
+++ b/src/modules/enrich/options_parser_enrich.cpp
@@ -19,15 +19,15 @@ bool options_parser_enrich::parse( int argc, char ***argv, options *opts )
     po::options_description desc( "PepSIRF "
                                   + format_version_string()
                                   + ": Peptide-based Serological Immune Response "
-                                  "Framework Paired (Duplicate) Enrichment module.\n",
+                                  "Framework Enrichment module.\n",
                                   line_width
                                 );
     desc.add_options()
         ( "help,h", "Produce help message and exit.\n"
-          "The p_enrich module determines which peptides are enriched in samples that "
-          "have been assayed in duplicate, as determined by user-specified thresholds. "
+          "The enrich module determines which peptides are enriched in samples that "
+          "have been assayed in n-replicate, as determined by user-specified thresholds. "
           "Thresholds are provided as comma-delimited pairs. In order for a peptide to "
-          "be considered enriched, both replicates must meet or exceed the lower threshold "
+          "be considered enriched, all replicates must meet or exceed the lower threshold "
           "and at least one replicate must meet or exceed the higher threshold, "
           "independent of order. Note that a peptide must meet each specified threshold "
           "(e.g., zscore, norm count and raw count) in order to be considered enriched.\n"
@@ -64,9 +64,9 @@ bool options_parser_enrich::parse( int argc, char ***argv, options *opts )
           "The provided thresholds should be comma-separated if more than one is provided for a single matrix file.\n"
         )
         ( "samples,s", po::value( &opts_enrich->in_samples_fname ),
-          "The name of the file containing sample pair information, denoting which "
+          "The name of the file containing sample information, denoting which "
           "samples, in the input matrices, are replicates. This file must be "
-          "tab-delimited with one pair of samples per line.\n"
+          "tab-delimited with each line a set of replicates.\n"
         )
         ( "raw_scores,r", po::value( &opts_enrich->in_raw_scores_fname )
           ->default_value( "" ),

--- a/src/modules/enrich/options_parser_enrich.cpp
+++ b/src/modules/enrich/options_parser_enrich.cpp
@@ -95,6 +95,15 @@ bool options_parser_enrich::parse( int argc, char ***argv, options *opts )
           "order for any of the peptides in that sample to be considered enriched. "
           "This provides a way to impose a minimum read count for a sample to be evaluated.\n"
         )
+        ( "enrichment_failure_reason,f", po::value( &opts_enrich->out_enrichment_failure )
+          ->default_value( "" ),
+          "For each sample set that does not result in the generation of an enriched peptide file, "
+          "a row of two tab-delimited columns is provided: the first column provides the reason why "
+          "the associated samplenames do not result in an enriched peptide file and the second column "
+          "contains the replicates comma-delimited.\n"
+          "This file is output to the same directory as the enriched peptide files. The 'Reason' column "
+          "will contain one of the following: 'Raw read count threshold' or 'No enriched peptides'.\n"
+        )
         ( "outfile_suffix,x",
           po::value( &opts_enrich->out_suffix )
           ->default_value( "" ),


### PR DESCRIPTION
This issue focused on an enhancement for the enrich module. If a replicate fails to meet a raw score or matrix threshold specified, it will result in the replicate set containing that replicate failing to generate any peptides. This additional option ("--enrichment_failure_reason, -f") being added will be helpful in giving more context to the user why the failure occurred. The plan is to expand this a little further in the future. Currently, a file with header "Replicates   Reason" is created. The replicates column contains a comma-delimited list of replicates and the reason column contains the respective reasoning for why the replicate set didn't generate an enriched peptides file. 