### PR TITLE
Added cmake flag to cmakelists file to prevent issue building pepsirf…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ list( APPEND PepSIRF_LINK_LIBS
 if(OpenMP_FOUND)
   message( "OpenMP enabled" )
   list( APPEND PepSIRF_LINK_LIBS OpenMP::OpenMP_CXX )
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xpreprocessor -fopenmp")
   add_definitions( -DENABLE_OPENMP )
 
 else()


### PR DESCRIPTION
Added cmake flag to cmakelists file to prevent issue building pepsirf in big sur environment. fopenmp, used for multithreading, was causing issue not being supported. The Xpreprocessor flag was added to assist in compiling across different environments. This issue was discovered by Evan Elko while attempting to build pepsirf on big sur. Closes #117 