### PR TITLE
Updating the link module to handle unfound sequences in metadata

### DIFF
--- a/src/modules/link/metadata_map.cpp
+++ b/src/modules/link/metadata_map.cpp
@@ -55,6 +55,6 @@ void metadata_map::build_map( std::unordered_map<std::string, std::string> *meta
             }
         else
             {
-                return 0;
+                return "";
             }
     }

--- a/src/modules/link/module_link.cpp
+++ b/src/modules/link/module_link.cpp
@@ -179,7 +179,12 @@ std::string module_link::verify_id_type( std::string sequence_data, std::size_t 
 
 std::string module_link::verify_id_type( std::string sequence_data, std::unordered_map<std::string, std::string> *map )
 {
-    return metadata_map::get_id( sequence_data, map );
+    std::string found_id = metadata_map::get_id( sequence_data, map );
+    if( found_id.empty() )
+        {
+            throw std::runtime_error("Protein file contains sequences not represented in metadata file");
+        }
+    return found_id;
 }
 
 void module_link::create_pep_map( std::unordered_map<std::string,


### PR DESCRIPTION
Updating the verification of ids to return an empty string instead of a zero integer. This way an error can be thrown if a sequence is not found as a match in the metadata map. This was developed during a meeting with Isaiah. Instead of comparing the sizes of protein sequences and the sequence ids in the metadata file, throwing an error when an id is not found in metadata may be a more suitable update to this. The former way of verifying the two datasets assumes the metadata file and the protein sequences file will contain the same amount of data. This change will not base off size and make that assumption.