### PR TITLE
Demux iss138

### DIFF
--- a/include/modules/demux/module_demux.h
+++ b/include/modules/demux/module_demux.h
@@ -88,7 +88,7 @@ class module_demux : public module
     void write_outputs( std::string outfile_name,
                         parallel_map<sequence, std::vector<std::size_t>*>& seq_scores,
                         std::vector<sample>& samples,
-                        std::map<std::string, std::size_t> id_duplicates
+                        std::map<std::string, std::size_t> seq_duplicates
                       );
 
 

--- a/src/modules/demux/module_demux.cpp
+++ b/src/modules/demux/module_demux.cpp
@@ -50,7 +50,7 @@ void module_demux::run( options *opts )
     parallel_map<sequence, std::size_t> non_perfect_match_seqs;
 
     sequential_map<sequence, sample> index_map;
-    std::map<std::string, std::size_t> id_duplicates;
+    std::map<std::string, std::size_t> seq_duplicates;
     std::unordered_map<std::string, std::vector<std::tuple<std::string, std::string, std::size_t>>> diagnostic_map;
     omp_set_num_threads( opts->num_threads );
 
@@ -77,17 +77,6 @@ void module_demux::run( options *opts )
                 }
         }
     std::vector<sample> samplelist = samplelist_p.parse( d_opts );
-
-    //set the duplicate ids
-    for(auto samp : samplelist)
-        {
-            std::string id_str = "";
-            for(std::string str : samp.string_ids)
-            {
-                id_str += str;
-            }
-            id_duplicates[id_str]++;
-        }
 
     std::ifstream reads_file( d_opts->input_r1_fname, std::ios_base::in );
     std::ifstream r2_reads;
@@ -213,11 +202,11 @@ void module_demux::run( options *opts )
                     fastq_p.parse( r2_reads_ref, r2_seqs, d_opts->read_per_loop );
                 }
 
-        //    #pragma omp parallel for private( seq_iter, nuc_seq, read_index, index_str, adapter, sample_id,  \
-        //                                       idx_match_list ) \
-        //        shared( seq_start, seq_length, d_opts, num_samples, reference_counts, library_seqs, index_seqs, r2_seqs ) \
-        //         reduction( +:processed_total, processed_success, concatemer_found ) \
-        //         schedule( dynamic )
+           #pragma omp parallel for private( seq_iter, nuc_seq, read_index, index_str, adapter, sample_id,  \
+                                              idx_match_list ) \
+               shared( seq_start, seq_length, d_opts, num_samples, reference_counts, library_seqs, index_seqs, r2_seqs, seq_duplicates ) \
+                reduction( +:processed_total, processed_success, concatemer_found ) \
+                schedule( dynamic )
 
             for( read_index = 0; read_index < reads.size(); ++read_index )
                 {
@@ -392,7 +381,16 @@ void module_demux::run( options *opts )
                                                                                     seq_start,
                                                                                     seq_length
                                                                                     );
-
+                                            // check for duplicate sequence
+                                            std::string seq_str = seq_match->first.name;
+                                            if( seq_duplicates.find( seq_str ) != seq_duplicates.end() )
+                                                {
+                                                    seq_duplicates[seq_str]++;
+                                                }
+                                            else
+                                                {
+                                                    seq_duplicates.insert( std::make_pair( seq_str, 1 ) );
+                                                }
                                             if( seq_match != reference_counts.end() )
                                                 {
                                                     seq_match->second->at(0) += 1;
@@ -420,6 +418,16 @@ void module_demux::run( options *opts )
                                                                                             seq_start,
                                                                                             seq_length
                                                                                             );
+                                                    // check for duplicate sequence
+                                                    std::string seq_str = seq_match->first.name;
+                                                    if( seq_duplicates.find( seq_str ) != seq_duplicates.end() )
+                                                        {
+                                                            seq_duplicates[seq_str]++;
+                                                        }
+                                                    else
+                                                        {
+                                                            seq_duplicates.insert( std::make_pair( seq_str, 1 ) );
+                                                        }
                                                     if( seq_match != reference_counts.end() )
                                                         {
                                                             sample_id = d_id->second.id;
@@ -492,10 +500,10 @@ void module_demux::run( options *opts )
             write_outputs( d_opts->aggregate_fname,
                            agg_map,
                            samplelist,
-                           id_duplicates
+                           seq_duplicates
                          );
         }
-    write_outputs( d_opts->output_fname, reference_counts, samplelist, id_duplicates );
+    write_outputs( d_opts->output_fname, reference_counts, samplelist, seq_duplicates );
     write_diagnostic_output( d_opts, diagnostic_map);
 }
 
@@ -634,7 +642,7 @@ void module_demux::write_diagnostic_output( options_demux* d_opts, std::unordere
 void module_demux::write_outputs( std::string outfile_name,
                                   parallel_map<sequence, std::vector<std::size_t>*>& seq_scores,
                                   std::vector<sample>& samples,
-                                  std::map<std::string, std::size_t> id_duplicates
+                                  std::map<std::string, std::size_t> seq_duplicates
                                 )
 {
     std::ofstream outfile( outfile_name, std::ofstream::out );
@@ -665,15 +673,18 @@ void module_demux::write_outputs( std::string outfile_name,
             const sequence& curr = seq_iter->first;
             const std::vector<std::size_t> *curr_counts = seq_iter->second;
 
-
-            outfile << curr.name << DELIMITER;
-
-            for( second_index = 0; second_index < curr_counts->size() - 1; ++second_index )
+            if( seq_duplicates.empty()
+                || ( seq_duplicates.find( curr.name ) != seq_duplicates.end() && seq_duplicates[curr.name] == 1 ) )
                 {
-                    outfile << curr_counts->at( second_index ) << DELIMITER;
-                }
-            outfile << curr_counts->at( curr_counts->size() - 1 ) << NEWLINE;
+                    outfile << curr.name << DELIMITER;
+                
 
+                    for( second_index = 0; second_index < curr_counts->size() - 1; ++second_index )
+                        {
+                            outfile << curr_counts->at( second_index ) << DELIMITER;
+                        }
+                    outfile << curr_counts->at( curr_counts->size() - 1 ) << NEWLINE;
+                }
             ++seq_iter;
             delete curr_counts;
         }


### PR DESCRIPTION
Adding ref-independent mode feature. Duplicate probe sequence names will not be included in the final output, but will still be used in the demultiplexing process. Closes #138 