### PR TITLE
Add duplicate checking in demux - samplename and index name set duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- #35, added new feature to demux. If samplenames or index name sets have duplicates in samplelist file, then those duplicates will be output to the terminal.
 - #57, demux now has an additional option for providing a tab-delimited file with 5 ordered columns: 1) index name, which should correspond to a header name in the sample sheet, 2) read name, which should be either "r1" or "r2" to specify whether the index is in "--input_r1" or "--input_r2", 3) index start location (0-based, inclusive), 4) index length and 5) number of mismatched to allow. Note: the last three columns correspond to the info currently provided on the command line with "--f_index" and "--r_index" (or "--index1" and "--index2", with recent changes). With this feature, the demux module can now analyze an arbitrary amount of indexes to be found in r1 or r2 input sequences.
 - #57, demux output diagnostics may now provide more index matches for flexibility with demux changes in #57.
 

--- a/src/modules/demux/module_demux.cpp
+++ b/src/modules/demux/module_demux.cpp
@@ -18,8 +18,6 @@ void module_demux::run( options *opts )
     // options from the command line
     options_demux *d_opts = (options_demux*) opts;
 
-    std::string index_str;
-
     // fif use case
     std::vector<flex_idx> flexible_idx_data;
     std::vector<sequential_map<sequence, sample>::iterator> idx_match_list;
@@ -203,7 +201,7 @@ void module_demux::run( options *opts )
                     fastq_p.parse( r2_reads_ref, r2_seqs, d_opts->read_per_loop );
                 }
 
-           #pragma omp parallel for private( seq_iter, nuc_seq, read_index, index_str, adapter, sample_id,  \
+           #pragma omp parallel for private( seq_iter, nuc_seq, read_index, adapter, sample_id,  \
                                               idx_match_list ) \
                shared( seq_start, seq_length, d_opts, num_samples, reference_counts, library_seqs, index_seqs, r2_seqs, seq_duplicates ) \
                 reduction( +:processed_total, processed_success, concatemer_found ) \
@@ -477,6 +475,10 @@ void module_demux::run( options *opts )
                 ( (long double) concatemer_found / (long double) processed_total ) * 100 << "% of total).\n";
         }
 
+    if( !d_opts->diagnostic_fname.empty() )
+        {
+            write_diagnostic_output( d_opts, diagnostic_map);
+        }
     if( d_opts->aggregate_fname.length() > 0  )
         {
             parallel_map<sequence, std::vector<std::size_t>*> agg_map;
@@ -505,7 +507,6 @@ void module_demux::run( options *opts )
                          );
         }
     write_outputs( d_opts->output_fname, reference_counts, samplelist, seq_duplicates );
-    write_diagnostic_output( d_opts, diagnostic_map);
 }
 
 


### PR DESCRIPTION
Update to samplelist parser to catch and output duplicate sample names or index names. Also fixed a bug in diagnostic output that got overwritten causing a bug. Diagnostic info should only be output if the filename is provided.
There was also an unused variable that could be removed. Closes #35 